### PR TITLE
Add simple message hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ Receives webhooks from Alertmanager.
 
 ### Gitlab
 Receives webhooks from Gitlab. Currently not all types are implemented!
+
+### Simple
+Receives arbitrary messages as text via a HTTP `POST` request and forwards this message line by line to a channel.
+The channel can be specified by the `channel` query parameter or the `default_channel` from the config is used.

--- a/cpthook.yml.example
+++ b/cpthook.yml.example
@@ -23,4 +23,7 @@ modules:
         explicit:
             "myGitlabGroup/mySpecialGitlabProject":
                 - "#specificChannel"
+    simple:
+        enabled: True
+        default_channel: "#defaultChannel"
 

--- a/main.go
+++ b/main.go
@@ -57,6 +57,12 @@ func main() {
 		http.HandleFunc("/gitlab", gitlabHandler(viper.Sub("modules.gitlab")))
 	}
 
+	// Simple module
+	if moduleList.GetBool("simple.enabled") {
+		log.Println("Simple module is active")
+		http.HandleFunc("/simple", simpleHandler(viper.Sub("modules.simple")))
+	}
+
 	// Start IRC connection
 	go ircConnection(viper.Sub("irc"))
 

--- a/simple.go
+++ b/simple.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"net/http"
+	"github.com/spf13/viper"
+	"bufio"
+)
+
+func simpleHandler(c *viper.Viper) http.HandlerFunc {
+
+	defaultChannel := c.GetString("default_channel")
+
+	return func(wr http.ResponseWriter, req *http.Request) {
+		defer req.Body.Close()
+
+		query := req.URL.Query()
+
+		// Get channel to send to
+		channel := query.Get("channel")
+		if channel == "" {
+			channel = defaultChannel
+		}
+
+		// Split body into lines
+		var lines []string
+		scanner := bufio.NewScanner(req.Body)
+		for scanner.Scan() {
+			lines = append(lines, scanner.Text())
+		}
+
+		// Send message
+		messageChannel <- IRCMessage{
+			Messages: lines,
+			Channel:  channel,
+		}
+	}
+}

--- a/simple_test.go
+++ b/simple_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/viper"
+	"strings"
+)
+
+func TestSimpleHandler(t *testing.T) {
+	viper.SetConfigName("cpthook")
+	viper.AddConfigPath(".")
+	err := viper.ReadInConfig()
+	if err != nil {
+		panic(fmt.Errorf("Fatal error config file: %s", err))
+	}
+
+	body := strings.NewReader("Hello, World!")
+
+	req, err := http.NewRequest("POST", "/", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(simpleHandler(viper.Sub("modules.simple")))
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("Handler returned wrong status code: got %v wanted %v",
+			status, http.StatusOK)
+	}
+}


### PR DESCRIPTION
This hook just reads the message to send from the HTTP body which makes it easy to use this as an replacement for irker.

The channel to send to can be selected by the `channel` query parameter.